### PR TITLE
Change of a 'method' that will be deprecated in the future

### DIFF
--- a/pyodv/base.py
+++ b/pyodv/base.py
@@ -128,7 +128,7 @@ class ODV_Struct(object):
 
         Also combine the variables into a multidimensional XArray
         '''
-        self.df_data = self.odv_df[self.cols_data].fillna(method='ffill')
+        self.df_data = self.odv_df[self.cols_data].ffill()
         self.df_var = self.odv_df[self.cols_variable]
         self.df_qc = self.odv_df[self.cols_quality]
         return


### PR DESCRIPTION
I've changed the method fillna() to ffill() because it will be deprecated in the future. 

Here is the warning message that triggered this change: 

/usr/local/lib/python3.9/site-packages/pyodv/base.py:131: FutureWarning: DataFrame.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.
self.df_data = self.odv_df[self.cols_data].fillna(method='ffill')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for handling missing data to propagate valid observations more efficiently, ensuring consistent data processing without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->